### PR TITLE
Update `createReplyUrl` to include port for local dev scenarios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/express-msal",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/express-msal",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@makerx/node-common": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/express-msal",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": false,
   "description": "",
   "author": "MakerX",

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ const createEnsureAuthenticatedHandler = (input: AuthInput): RequestHandler => {
 const PROXY_PATH = process.env.PROXY_PATH ?? ''
 const createReplyUrl = (req: Request, replyRoute: string) => {
   // See https://expressjs.com/en/4x/api.html#req.hostname
-  const hostAndPort = req.get('Host') ?? ''
+  const hostAndPort = req.header('Host') ?? ''
   const reverseProxyAwareHost = req.hostname
 
   // Setting hostname does *not* change the port

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,16 @@ const createEnsureAuthenticatedHandler = (input: AuthInput): RequestHandler => {
 
 const PROXY_PATH = process.env.PROXY_PATH ?? ''
 const createReplyUrl = (req: Request, replyRoute: string) => {
-  const hostAndPort = req.hostname ?? ''
-  return `${req.protocol}://${hostAndPort}${PROXY_PATH}${replyRoute}`
+  // See https://expressjs.com/en/4x/api.html#req.hostname
+  const hostAndPort = req.get('Host') ?? ''
+  const reverseProxyAwareHost = req.hostname
+
+  // Setting hostname does *not* change the port
+  // See https://nodejs.org/docs/latest-v18.x/api/url.html#urlhostname
+  const url = new URL(`${req.protocol}://${hostAndPort}${PROXY_PATH}${replyRoute}`)
+  url.hostname = reverseProxyAwareHost
+
+  return url.toString()
 }
 
 const createLoginHandler = ({ msalClient, scopes, authReplyRoute, authorizationUrlRequestOverride }: AuthInput): RequestHandler => {


### PR DESCRIPTION
Follow-up to #8 

## What

Sam found out that `req.hostname` does **not** include the port, which means the logic is buggy for local dev scenarios where we host our apps over non-default ports.

I didn't want to manipulate `<host>:<port>` strings manually, and ended up using `URL`.

## Test

If you want to test this locally, here's the locally compiled version that you can replace in your `node_modules` directory.

<details>
<summary>Click to expand</summary>

```javascript
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
exports.toNpmLogLevel = exports.NpmLogLevel = exports.pkceAuthenticationMiddleware = exports.copySessionJwtToBearerHeader = exports.logout = exports.isAuthenticatedSession = void 0;
const msal_node_1 = require("@azure/msal-node");
const isCookieSession = (session) => {
    return 'isChanged' in session && 'isNew' in session && 'isPopulated' in session;
};
const isPKCEStartedSession = (session) => {
    return Boolean(session?.pkceCodes);
};
const isAuthenticatedSession = (session) => {
    return session?.isAuthenticated === true;
};
exports.isAuthenticatedSession = isAuthenticatedSession;
const createEnsureAuthenticatedHandler = (input) => {
    const login = createLoginHandler(input);
    return (req, res, next) => {
        if (!req.session)
            throw Error('Express session is not available');
        if (!isCookieSession(req.session))
            throw Error('Only cookie-session sessions are supported');
        if ((0, exports.isAuthenticatedSession)(req.session))
            return next();
        login(req, res, next);
    };
};
const PROXY_PATH = process.env.PROXY_PATH ?? '';
const createReplyUrl = (req, replyRoute) => {
    // See https://expressjs.com/en/4x/api.html#req.hostname
    const hostAndPort = req.get('Host') ?? '';
    const reverseProxyAwareHost = req.hostname;
    // Setting hostname does *not* change the port
    // See https://nodejs.org/docs/latest-v18.x/api/url.html#urlhostname
    const url = new URL(`${req.protocol}://${hostAndPort}${PROXY_PATH}${replyRoute}`);
    url.hostname = reverseProxyAwareHost;
    return url.toString();
};
const createLoginHandler = ({ msalClient, scopes, authReplyRoute, authorizationUrlRequestOverride }) => {
    const cryptoProvider = new msal_node_1.CryptoProvider();
    return (req, res) => {
        cryptoProvider
            .generatePkceCodes()
            .then(async ({ verifier, challenge }) => {
            const pkceCodes = {
                challengeMethod: 'S256',
                verifier,
                challenge,
            };
            req.session = { pkceCodes, originalUrl: `${PROXY_PATH}${req.originalUrl}` };
            const authorizationUrlRequest = authorizationUrlRequestOverride ? await Promise.resolve(authorizationUrlRequestOverride(req)) : {};
            return {
                scopes,
                ...authorizationUrlRequest,
                redirectUri: createReplyUrl(req, authReplyRoute),
                codeChallenge: pkceCodes.challenge,
                codeChallengeMethod: pkceCodes.challengeMethod,
            };
        })
            .then((authCodeUrlParameters) => msalClient.getAuthCodeUrl(authCodeUrlParameters))
            .then((response) => res.redirect(response))
            .catch((error) => {
            throw error;
        });
    };
};
const createAuthHandler = ({ msalClient, scopes, authReplyRoute, augmentSession, logger }) => {
    return (req, res) => {
        if (!isPKCEStartedSession(req.session))
            throw Error('Invalid session data for this (auth reply) route');
        const { originalUrl, pkceCodes: { verifier }, } = req.session;
        const tokenRequest = {
            code: req.query.code,
            scopes,
            redirectUri: createReplyUrl(req, authReplyRoute),
            codeVerifier: verifier,
            clientInfo: req.query.client_info,
        };
        msalClient
            .acquireTokenByCode(tokenRequest)
            .then((response) => {
            if (!response) {
                logger?.error('acquireTokenByCode did not return a response');
                return res.status(500).send('acquireTokenByCode did not return a response').end();
            }
            let session = {
                isAuthenticated: true,
                accessToken: response?.accessToken,
            };
            if (augmentSession)
                session = { ...session, ...augmentSession(response) };
            req.session = session;
            res.redirect(originalUrl);
            if (logger) {
                const { authority, uniqueId, tenantId, scopes } = response;
                logger?.info('User logged in via PCKE', { authority, uniqueId, tenantId, scopes });
            }
        })
            .catch((error) => {
            logger?.error('Failed to acquireTokenByCode', { error });
            res.status(500).send('acquireTokenByCode failed').end();
        });
    };
};
const logout = (req, res) => {
    req.session = null;
    res.send('🙋🏽‍♀️').end();
};
exports.logout = logout;
const copySessionJwtToBearerHeader = (req, _res, next) => {
    const session = req.session;
    if (!(0, exports.isAuthenticatedSession)(session))
        return next();
    req.headers.authorization = `Bearer ${session.accessToken}`;
    next();
};
exports.copySessionJwtToBearerHeader = copySessionJwtToBearerHeader;
const pkceAuthenticationMiddleware = ({ app, msalClient, scopes, authReplyRoute = '/auth', augmentSession, logger, authorizationUrlRequestOverride, }) => {
    const ensureAuthenticated = createEnsureAuthenticatedHandler({
        msalClient,
        scopes,
        authReplyRoute,
        authorizationUrlRequestOverride,
    });
    app.get(authReplyRoute, createAuthHandler({ msalClient, scopes, authReplyRoute, augmentSession, logger }));
    logger?.info(`Auth reply handler added to route ${authReplyRoute}`);
    return ensureAuthenticated;
};
exports.pkceAuthenticationMiddleware = pkceAuthenticationMiddleware;
var NpmLogLevel;
(function (NpmLogLevel) {
    NpmLogLevel[NpmLogLevel["error"] = 0] = "error";
    NpmLogLevel[NpmLogLevel["warn"] = 1] = "warn";
    NpmLogLevel[NpmLogLevel["info"] = 2] = "info";
    NpmLogLevel[NpmLogLevel["http"] = 3] = "http";
    NpmLogLevel[NpmLogLevel["verbose"] = 4] = "verbose";
    NpmLogLevel[NpmLogLevel["debug"] = 5] = "debug";
    NpmLogLevel[NpmLogLevel["silly"] = 6] = "silly";
})(NpmLogLevel || (exports.NpmLogLevel = NpmLogLevel = {}));
const toNpmLogLevel = (level) => {
    switch (level) {
        case msal_node_1.LogLevel.Error:
            return 'error';
        case msal_node_1.LogLevel.Warning:
            return 'warn';
        case msal_node_1.LogLevel.Info:
            return 'info';
        case msal_node_1.LogLevel.Verbose:
            return 'verbose';
        case msal_node_1.LogLevel.Trace:
            return 'debug';
    }
};
exports.toNpmLogLevel = toNpmLogLevel;
```

</details>