### PR TITLE
fix: surface auth reply errors instead of swallowing them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/express-msal",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/express-msal",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.2",
@@ -2177,9 +2177,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3932,9 +3932,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -6759,9 +6759,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/express-msal",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": false,
   "description": "An express middleware for PKCE via Microsoft Authentication Library for Node (MSAL Node).",
   "author": "MakerX",

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,11 @@ const createAuthHandler = ({ msalClient, scopes, authReplyRoute, augmentSession,
       pkceCodes: { verifier },
     } = req.session
 
+    if (req.query.error) {
+      logger?.error('Error returned in auth reply query parameters', { error: req.query.error, query: req.query })
+      throw new Error(req.query.error as string, { cause: req.query })
+    }
+
     const tokenRequest: AuthorizationCodeRequest = {
       code: req.query.code as string,
       scopes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,8 +115,9 @@ const createAuthHandler = ({ msalClient, scopes, authReplyRoute, augmentSession,
     } = req.session
 
     if (req.query.error) {
-      logger?.error('Error returned in auth reply query parameters', { error: req.query.error, query: req.query })
-      throw new Error(req.query.error as string, { cause: req.query })
+      const details = { error: req.query.error, error_description: req.query.error_description }
+      logger?.error('Error returned in auth reply query parameters', details)
+      throw new Error(req.query.error as string, { cause: details })
     }
 
     const tokenRequest: AuthorizationCodeRequest = {


### PR DESCRIPTION
## Summary
- Throw an error when the auth reply URL contains an `error` query parameter, so failures from the identity provider surface instead of being silently swallowed during token exchange.
- Log the error and full query via the optional logger for diagnosability.
- Bump package version to 2.0.1.

## Details on current behaviour
- When there is an error encoded into the reply URL, this is currently missed, not thrown or logged
- The subsequent `acquireTokenByCode` ends up running without `code`, so a different error is thrown and logged, obscuring the actual error

## Test plan
- [ ] Trigger an auth flow where the identity provider returns an `error` query param (e.g. user cancels consent) and confirm the middleware surfaces the error rather than failing opaquely during token exchange.
- [ ] Confirm the happy path (successful auth reply with `code`) still completes as before.
- [ ] Verify the logger receives the error message and query payload when provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)