### PR TITLE
fix: respond 500 instead of crashing when login initiation fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export const isAuthenticatedSession = (session: MaybeSession): session is Authen
   return session?.isAuthenticated === true
 }
 
-type AuthInput = Pick<AuthConfig, 'scopes'> & {
+type AuthInput = Pick<AuthConfig, 'scopes' | 'logger'> & {
   msalClient: IConfidentialClientApplication
   authReplyRoute: string
   authorizationUrlRequestOverride?: AuthConfig['authorizationUrlRequestOverride']
@@ -67,7 +67,7 @@ const createReplyUrl = (req: Request, replyRoute: string) => {
   return url.toString()
 }
 
-const createLoginHandler = ({ msalClient, scopes, authReplyRoute, authorizationUrlRequestOverride }: AuthInput): RequestHandler => {
+const createLoginHandler = ({ msalClient, scopes, authReplyRoute, authorizationUrlRequestOverride, logger }: AuthInput): RequestHandler => {
   const cryptoProvider = new CryptoProvider()
 
   return (req, res) => {
@@ -95,7 +95,10 @@ const createLoginHandler = ({ msalClient, scopes, authReplyRoute, authorizationU
       .then((authCodeUrlParameters) => msalClient.getAuthCodeUrl(authCodeUrlParameters))
       .then((response) => res.redirect(response))
       .catch((error: unknown) => {
-        throw error
+        // rethrowing inside a terminal .catch becomes an unhandled promise rejection, which kills
+        // the process — respond 500 instead, matching createAuthHandler's error handling
+        logger?.error('Failed to initiate interactive login', { error })
+        if (!res.headersSent) res.status(500).send('Failed to initiate login').end()
       })
   }
 }
@@ -198,6 +201,7 @@ export const pkceAuthenticationMiddleware = ({
     scopes,
     authReplyRoute,
     authorizationUrlRequestOverride,
+    logger,
   })
 
   app.get(authReplyRoute, createAuthHandler({ msalClient, scopes, authReplyRoute, augmentSession, logger }))

--- a/src/login-handler.spec.ts
+++ b/src/login-handler.spec.ts
@@ -1,0 +1,63 @@
+import { IConfidentialClientApplication } from '@azure/msal-node'
+import { Express, NextFunction, Request, Response } from 'express'
+import { describe, expect, it, vi } from 'vitest'
+import { pkceAuthenticationMiddleware } from './index'
+
+const createRequest = (): Request =>
+  ({
+    // cookie-session shape (isCookieSession) that is not yet authenticated, so the login handler runs
+    session: { isChanged: false, isNew: true, isPopulated: false },
+    originalUrl: '/some/page',
+    protocol: 'https',
+    hostname: 'api.example.com',
+    headers: {},
+    header: () => 'api.example.com',
+  }) as unknown as Request
+
+const createResponse = (): Response =>
+  ({
+    headersSent: false,
+    redirect: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    end: vi.fn(),
+  }) as unknown as Response
+
+const createMiddleware = (msalClient: IConfidentialClientApplication) =>
+  pkceAuthenticationMiddleware({
+    app: { get: vi.fn() } as unknown as Express,
+    msalClient,
+    scopes: ['openid'],
+    logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), verbose: vi.fn(), debug: vi.fn() },
+  })
+
+describe('login handler', () => {
+  it('responds 500 instead of crashing when login initiation fails', async () => {
+    const msalClient = {
+      getAuthCodeUrl: vi.fn().mockRejectedValue(new Error('Entra metadata fetch failed')),
+    } as unknown as IConfidentialClientApplication
+    const ensureAuthenticated = createMiddleware(msalClient)
+    const res = createResponse()
+
+    ensureAuthenticated(createRequest(), res, vi.fn() as NextFunction)
+
+    // without the terminal .catch fix this rejection escapes the promise chain and takes the process down
+    await vi.waitFor(() => expect(res.status).toHaveBeenCalledWith(500))
+    expect(res.send).toHaveBeenCalledWith('Failed to initiate login')
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+
+  it('redirects to the auth code URL when login initiation succeeds', async () => {
+    const authCodeUrl = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=test'
+    const msalClient = {
+      getAuthCodeUrl: vi.fn().mockResolvedValue(authCodeUrl),
+    } as unknown as IConfidentialClientApplication
+    const ensureAuthenticated = createMiddleware(msalClient)
+    const res = createResponse()
+
+    ensureAuthenticated(createRequest(), res, vi.fn() as NextFunction)
+
+    await vi.waitFor(() => expect(res.redirect).toHaveBeenCalledWith(authCodeUrl))
+    expect(res.status).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
> **Stack 2/3** — stacked on #17 (base branch `chore/npm-audit`); the diff shows only this PR's commit. Merge #17 first, then this, then #16. The version bump for the release ships at the top of the stack in #16.

## Problem

`createLoginHandler`'s promise chain ends in a terminal `.catch((error) => { throw error })`. Rethrowing inside a terminal catch converts the error into an **unhandled promise rejection**, which terminates the Node process (default behaviour since Node 15).

Any failure while initiating an interactive login — e.g. a transient Entra metadata fetch error inside `msalClient.getAuthCodeUrl`, or a throwing `authorizationUrlRequestOverride` — is reachable by an anonymous `GET` with `accept: text/html`, so a single request during an Entra blip takes the whole server down.

## Fix

Log the error via the configured logger and respond `500`, matching `createAuthHandler`'s existing error handling. `logger` is now threaded through `AuthInput` to `createLoginHandler` for this purpose (no public API change — `AuthConfig` already has `logger`).

## Testing

Added `src/login-handler.spec.ts` (first tests in the repo — `vitest` was already wired up):
- login initiation failure responds 500 (under the old code this test run dies on the unhandled rejection)
- successful initiation still redirects to the auth code URL

`npm run lint`, `npm run check-types`, and `npm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
