### PR TITLE
fix: drop sessions carrying an expired access token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@makerx/express-msal",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@makerx/express-msal",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerx/express-msal",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "private": false,
   "description": "An express middleware for PKCE via Microsoft Authentication Library for Node (MSAL Node).",
   "author": "MakerX",

--- a/src/copy-session-jwt-to-bearer-header.spec.ts
+++ b/src/copy-session-jwt-to-bearer-header.spec.ts
@@ -1,0 +1,46 @@
+import { NextFunction, Request, Response } from 'express'
+import { describe, expect, it, vi } from 'vitest'
+import { copySessionJwtToBearerHeader } from './index'
+
+const jwtWithExp = (exp: number) =>
+  `${Buffer.from('{}').toString('base64')}.${Buffer.from(JSON.stringify({ exp })).toString('base64')}.signature`
+
+const secondsFromNow = (seconds: number) => Math.floor(Date.now() / 1000) + seconds
+
+const run = (session: Request['session'], authorization?: string) => {
+  const req = { headers: { authorization }, session } as unknown as Request
+  const next = vi.fn()
+  copySessionJwtToBearerHeader(req, {} as Response, next as NextFunction)
+  expect(next).toHaveBeenCalledOnce()
+  return req
+}
+
+describe('copySessionJwtToBearerHeader', () => {
+  it('copies an unexpired session token to the authorization header', () => {
+    const accessToken = jwtWithExp(secondsFromNow(60))
+    const req = run({ isAuthenticated: true, accessToken })
+    expect(req.headers.authorization).toBe(`Bearer ${accessToken}`)
+    expect(req.session).not.toBeNull()
+  })
+
+  it('drops the session and copies nothing when the token has expired', () => {
+    const req = run({ isAuthenticated: true, accessToken: jwtWithExp(secondsFromNow(-60)) })
+    expect(req.headers.authorization).toBeUndefined()
+    expect(req.session).toBeNull()
+  })
+
+  it('passes an unparsable token through for downstream bearer verification to reject', () => {
+    const req = run({ isAuthenticated: true, accessToken: 'not-a-jwt' })
+    expect(req.headers.authorization).toBe('Bearer not-a-jwt')
+  })
+
+  it('leaves an existing authorization header alone', () => {
+    const req = run({ isAuthenticated: true, accessToken: jwtWithExp(secondsFromNow(60)) }, 'Bearer existing')
+    expect(req.headers.authorization).toBe('Bearer existing')
+  })
+
+  it('does nothing for an unauthenticated session', () => {
+    const req = run({})
+    expect(req.headers.authorization).toBeUndefined()
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,9 +166,28 @@ export const logout: RequestHandler = (req, res) => {
   res.send('🙋🏽‍♀️').end()
 }
 
+// decode the JWT exp claim (no verification — that's the resource server's job);
+// unparsable tokens pass through so downstream bearer verification decides
+const sessionJwtIsExpired = ({ accessToken }: AuthenticatedSession): boolean => {
+  try {
+    const payload = JSON.parse(Buffer.from(accessToken.split('.')[1], 'base64').toString()) as { exp?: unknown }
+    return typeof payload.exp === 'number' && payload.exp * 1000 <= Date.now()
+  } catch {
+    return false
+  }
+}
+
 export const copySessionJwtToBearerHeader: RequestHandler = (req, _res, next) => {
   const session = req.session
   if (!!req.headers.authorization || !isAuthenticatedSession(session)) return next()
+  // the session cookie can outlive the access token it carries — an expired token would fail
+  // bearer verification downstream while its presence in the authorization header suppresses
+  // interactive re-login, wedging the browser on 401s until the cookie expires. Drop the
+  // session instead so the login middleware re-runs.
+  if (sessionJwtIsExpired(session)) {
+    req.session = null
+    return next()
+  }
   req.headers.authorization = `Bearer ${session.accessToken}`
   next()
 }


### PR DESCRIPTION
> **Stack 3/3** — stacked on #15 (base branch `fix/login-unhandled-rejection`); the diff shows only this PR's commits. Merging the full stack releases **v2.1.0** — this PR includes the minor version bump, so the publish workflow ships both fixes when it lands on `main`.

## Problem

The session cookie can outlive the access token it stores (e.g. a 1h cookie holding a token Entra issued with a shorter lifetime, or any visit after token expiry but before cookie expiry). When that happens:

1. `copySessionJwtToBearerHeader` keeps copying the expired token to the `authorization` header, where it fails bearer verification on the resource server → 401/FORBIDDEN.
2. The header's presence suppresses the interactive re-login redirect that apps typically gate on the header being *absent* (the pattern in this package's README).

The browser is wedged on 401s until the cookie expires or the user manually logs out.

## Fix

Decode the token's `exp` claim — plain base64 payload decode, **no signature verification**, which remains the resource server's job — and when it has expired, drop the session (`req.session = null`) and skip the copy. The login middleware then re-runs on the same request, giving the user a transparent SSO redirect instead of a dead end. Unparsable tokens still pass through untouched for downstream bearer verification to judge, exactly as before.

Also bumps the package version to **2.1.0** as the top of the stack.

## Testing

Added `src/copy-session-jwt-to-bearer-header.spec.ts`:
- unexpired token is copied to the header (unchanged behaviour)
- expired token → session dropped, nothing copied
- unparsable token passes through
- existing `authorization` header and unauthenticated sessions untouched

`npm run lint`, `npm run check-types`, and `npm test` all pass, plus `npm run build` and `npm run audit` on the assembled stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
